### PR TITLE
Edited slice.

### DIFF
--- a/seasonal/pages/results.js
+++ b/seasonal/pages/results.js
@@ -12,7 +12,7 @@ export default function Results() {
   useEffect(() => {
     const fetchData = async () => {
       console.log(JSON.stringify(router.query));
-      let modifiedMonth = router.query.month.slice(0, 3);
+      let modifiedMonth = router.query.month;
       const data = await fetch(`${searchString}?month=${modifiedMonth}`);
       let result = await data.json();
       setSearchResults(result);


### PR DESCRIPTION
Removed `.slice(0, 3)` from the end of the `modifiedMonth` declaration in `/pages/results` so that the front end now sends whole-word queries for month searches to the back end, to match the recent data update in our database.

Not added any handling for searches that aren't the full month, but added to team Trello as a stretch goal.