### PR TITLE
Move p line space styling to globals from card

### DIFF
--- a/seasonal/styles/Card.module.css
+++ b/seasonal/styles/Card.module.css
@@ -100,9 +100,7 @@
   max-width: 850px;
   margin: 0 auto;
   padding: 1rem 0;
-  line-height: 200%;
   text-align: left;
-
 }
 
 

--- a/seasonal/styles/globals.css
+++ b/seasonal/styles/globals.css
@@ -23,3 +23,7 @@ body {
   box-sizing: border-box;
 }
 
+p {
+  line-height: 200%;
+}
+


### PR DESCRIPTION
Moved line-spacing for all p tags to globals from card so about page is also fixed

Co-authored-by: Fiona Kitchen 100845392+fkit00@users.noreply.github.com