### PR TITLE
Updated to tested colours, added hover var.

### DIFF
--- a/seasonal/styles/Button.module.css
+++ b/seasonal/styles/Button.module.css
@@ -13,9 +13,9 @@
 }
 
 .buttonbox:hover > .button {
-  background: #296243c0;
+  background: var(--accent-button);
   border: 0px 1px 1px 1px solid;
-  border-color: var(--accent-one);
+  border-color: var(--accent-button);
   cursor: pointer;
   transition: linear 0.2s;
 }
@@ -23,7 +23,7 @@
 .buttonbox:hover > .buttonimage {
   border: 1px;
   border-style: solid;
-  border-color: #296243c0 /* var(--accent-one) */;
+  border-color: var(--accent-button) /* var(--accent-one) */;
   border-radius: 5px 5px 0px 0px;
   cursor: pointer;
 }
@@ -77,9 +77,9 @@
 }
 
 .buttonbox:hover > .recipeButton {
-  background: #296243c0;
+  background: var(--accent-button);
   border: 0px 1px 1px 1px solid;
-  border-color: var(--accent-one);
+  border-color: var(--accent-button);
   cursor: pointer;
   transition: linear 0.2s;
 }

--- a/seasonal/styles/MoreButton.module.css
+++ b/seasonal/styles/MoreButton.module.css
@@ -13,10 +13,10 @@
 }
 
 .morebutton:hover {
-  background: #296243c0;
+  background: var(--accent-button);
   /*   opacity: 0.8; */
   border: 0px 1px 1px 1px solid;
-  border-color: var(--accent-one);
+  border-color: var(--accent-button);
   cursor: pointer;
   transition: linear 0.2s;
 }

--- a/seasonal/styles/SearchBar.module.css
+++ b/seasonal/styles/SearchBar.module.css
@@ -30,13 +30,13 @@
   height: 35px;
 }
 
-.submitButton:hover{
-  background: #296243c0; 
+.submitButton:hover {
+  background: var(--accent-button);
   /*   opacity: 0.8; */
-    border: 0px 1px 1px 1px solid;
-    border-color:  var(--accent-one); 
-    cursor: pointer;
-    transition: linear 0.2s;
+  border: 0px 1px 1px 1px solid;
+  border-color: var(--accent-button);
+  cursor: pointer;
+  transition: linear 0.2s;
 }
 
 .visuallyHidden {

--- a/seasonal/styles/globals.css
+++ b/seasonal/styles/globals.css
@@ -6,26 +6,29 @@
   --main-darkest: #000000;
   --accent-one: #296243;
   --accent-two: #b1d0b6;
-  --accent-three: #e54a4a;
+  --accent-button: #5d866f;
 }
 
-html[data-theme="autumn"] {
-  --accent-one: #612948;
-  --accent-two: #e0b4cc;
-}
-html[data-theme="winter"] {
-  --accent-one: #2C5784;
-  --accent-two: #B8CFE7;
-}
 html[data-theme="spring"] {
-  --accent-one: #BB9F06;
-  --accent-two: #FCF0A7;
+  --accent-one: #6b1933;
+  --accent-two: #cc708d;
+  --accent-button: #a42850;
 }
 html[data-theme="summer"] {
   --accent-one: #296243;
   --accent-two: #b1d0b6;
+  --accent-button: #5d866f;
 }
-
+html[data-theme="autumn"] {
+  --accent-one: #851e12;
+  --accent-two: #d07066;
+  --accent-button: #c44536;
+}
+html[data-theme="winter"] {
+  --accent-one: #04344e;
+  --accent-two: #96a9b5;
+  --accent-button: #185a7d;
+}
 
 html,
 body {


### PR DESCRIPTION
Co-authored-by: Fiona Kitchen <100845392+fkit00@users.noreply.github.com>

Added in a variable for the button accent hover colour - `(--accent-button)` - inside `globals.css` and updated our colour swatches inside the same file accordingly. Colours have been colour tested: darker colours that are read against the most pass WCAG AAA, and the mid and lighter tones that are for hover contrast and the decorative bottom bar pass at WCAG AA minimum. The mid tone is only read against on hover, and the light tone is never read against.

Colours don't have to be final! But are tested and the variables have been made more reusable, so a stronger starting point.